### PR TITLE
Add parameters for secedit values

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,10 @@ class centrify (
   $private_group       = $centrify::params::private_group,
   $primary_gid         = $centrify::params::primary_gid,
   $auto_join           = $centrify::params::auto_join,
+  $maximumpasswordage  = $centrify::params::maximumpasswordage,
+  $minimumpasswordage  = $centrify::params::minimumpasswordage,
+  $lockoutduration     = $centrify::params::lockoutduration,
+  $lockoutbadcount     = $centrify::params::lockoutbadcount,
 ) inherits centrify::params {
 
   # validate parameters

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,4 +40,8 @@ class centrify::params {
   $private_group       = true
   $primary_gid         = ''
   $auto_join           = true
+  $maximumpasswordage  = '90'
+  $minimumpasswordage  = '1'
+  $lockoutduration     = '30'
+  $lockoutbadcount     = '0'
 }

--- a/templates/centrifydc_config.erb
+++ b/templates/centrifydc_config.erb
@@ -2065,7 +2065,7 @@ UBYLIB, RUBYOPT,KRB5_CONFIG,KRB5_KTNAME,VAR_ACE,USR_ACE,DLC_ACE, SHLIB_PATH, LDR
 # using Windows Group Policy.  Changing the value in this file will have no
 # effect.
 #
-secedit.system.access.maximumpasswordage: 90
+secedit.system.access.maximumpasswordage: <%= @maximumpasswordage %>
 #
 
 #
@@ -2091,7 +2091,7 @@ secedit.system.access.maximumpasswordage: 90
 # using Windows Group Policy.  Changing the value in this file will have no
 # effect.
 #
-secedit.system.access.minimumpasswordage: 1
+secedit.system.access.minimumpasswordage: <%= @minimumpasswordage %>
 #
 
 # Determines the number of minutes a locked-out account remains locked out
@@ -2113,7 +2113,7 @@ secedit.system.access.minimumpasswordage: 1
 # the machine group policies are updated, the settings will revert back to
 # Windows group policy settings.
 #
-# secedit.system.access.lockoutduration: 30
+secedit.system.access.lockoutduration: <%= @lockoutduration %>
 #
 
 # Account lockout threshold
@@ -2143,7 +2143,7 @@ secedit.system.access.minimumpasswordage: 1
 # the machine group policies are updated, the settings will revert back to
 # Windows group policy settings.
 #
-secedit.system.access.lockoutbadcount: 0
+secedit.system.access.lockoutbadcount: <%= @lockoutbadcount %>
 #
 
 #


### PR DESCRIPTION
The secedit.\* parameters in centrifydc.conf are overwritten by Windows
Group Policies, causing every puppet run to overwrite the config file if
the settings differ.

Add parameters for:
- maximumpasswordage
- minimumpasswordage
- lockoutduration
- lockoutbadcount
