### PR TITLE
Add support for Centrify Enterprise

### DIFF
--- a/lib/facter/centrify_facts.rb
+++ b/lib/facter/centrify_facts.rb
@@ -1,0 +1,57 @@
+# Centrify facter facts
+require 'facter'
+
+# centrify_connected: true/nil
+Facter.add('centrify_connected') do
+  confine :kernel => :linux
+
+  setcode do
+    connected = nil
+    if File::executable?("/usr/bin/adinfo")
+      connected = Facter::Util::Resolution.exec("/usr/bin/adinfo -m")
+      if connected == connected
+        connected = true
+      end
+    end
+    connected
+  end
+end
+
+# centrify domain controller
+Facter.add('centrify_dc') do
+  confine :centrify_connected => true
+
+  setcode do
+    dc = Facter::Util::Resolution.exec('/usr/bin/adinfo -r')
+    dc.nil? ? nil : dc
+  end
+end
+
+# centrify domain
+Facter.add('centrify_domain') do
+  confine :centrify_connected => true
+
+  setcode do
+    domain = Facter::Util::Resolution.exec('/usr/bin/adinfo -d')
+    domain.nil? ? nil : domain
+  end
+end
+
+# centrify mode
+Facter.add('centrify_mode') do
+
+  setcode do
+    mode = Facter::Util::Resolution.exec('/usr/bin/adinfo -m')
+    mode.nil? ? nil : mode
+  end
+end
+
+# centrify zone
+Facter.add('centrify_zone') do
+  confine :centrify_connected => true
+
+  setcode do
+    zone = Facter::Util::Resolution.exec('/usr/bin/adinfo -z')
+    zone.nil? ? nil : zone
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@ class centrify (
   $ssh_service_enable     = $centrify::params::ssh_service_enable,
   $ssh_service_ensure     = $centrify::params::ssh_service_ensure,
   $auth_servers           = $centrify::params::auth_servers,
+  $local_allow            = $centrify::params::local_allow,
   $group_overrides        = $centrify::params::group_overrides,
   $groups_allow           = $centrify::params::groups_allow,
   $users_allow            = $centrify::params::users_allow,
@@ -31,13 +32,21 @@ class centrify (
   $adjoin_password        = $centrify::params::adjoin_password,
   $adjoin_domain          = $centrify::params::adjoin_domain,
   $adjoin_server          = $centrify::params::adjoin_server,
+  $adjoin_zone            = $centrify::params::adjoin_zone,
+  $adjoin_container       = $centrify::params::adjoin_container,
+  $adjoin_force           = $centrify::params::adjoin_force,
   $private_group          = $centrify::params::private_group,
   $primary_gid            = $centrify::params::primary_gid,
   $auto_join              = $centrify::params::auto_join,
+  $cache_flush_int        = $centrify::params::cache_flush_int,
+  $cache_obj_life         = $centrify::params::cache_obj_life,
+  $log_buffer             = $centrify::params::log_buffer,
   $maximum_password_age   = $centrify::params::maximum_password_age,
   $minimum_password_age   = $centrify::params::minimum_password_age,
+  $password_warn          = $centrify::params::password_warn,
   $lockout_duration       = $centrify::params::lockout_duration,
   $lockout_bad_count      = $centrify::params::lockout_bad_count,
+  $sntp_enabled           = $centrify::params::sntp_enabled,
   $merge_groups           = $centrify::params::merge_groups,
 ) inherits centrify::params {
 
@@ -53,6 +62,7 @@ class centrify (
   validate_bool($ssh_service_enable)
   validate_string($ssh_service_ensure)
   validate_array($auth_servers)
+  validate_bool($local_allow)
   validate_array($group_overrides)
   validate_array($groups_allow)
   validate_array($users_allow)
@@ -60,13 +70,21 @@ class centrify (
   validate_string($adjoin_password)
   validate_string($adjoin_domain)
   validate_string($adjoin_server)
+  validate_string($adjoin_zone)
+  validate_string($adjoin_container)
+  validate_bool($adjoin_force)
   validate_bool($private_group)
   validate_string($primary_gid)
   validate_bool($auto_join)
+  validate_string($cache_flush_int)
+  validate_string($cache_obj_life)
+  validate_bool($log_buffer)
   validate_string($maximum_password_age)
   validate_string($minimum_password_age)
+  validate_string($password_warn)
   validate_string($lockout_duration)
   validate_string($lockout_bad_count)
+  validate_bool($sntp_enabled)
   validate_bool($merge_groups)
 
   # include classes for install, config and services

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class centrify::params {
   $ssh_service_enable     = true
   $ssh_service_ensure     = 'running'
   $auth_servers           = []
+  $local_allow            = true
   $group_overrides        = []
   $groups_allow           = []
   $users_allow            = []
@@ -34,12 +35,20 @@ class centrify::params {
   $adjoin_password        = ''
   $adjoin_domain          = ''
   $adjoin_server          = ''
+  $adjoin_zone            = ''
+  $adjoin_container       = ''
+  $adjoin_force           = false
   $private_group          = true
   $primary_gid            = ''
   $auto_join              = true
+  $cache_flush_int        = '24'
+  $cache_obj_life         = '24'
+  $log_buffer             = false
   $maximum_password_age   = '90'
   $minimum_password_age   = '1'
+  $password_warn          = '14'
   $lockout_duration       = '30'
   $lockout_bad_count      = '0'
+  $sntp_enabled           = false
   $merge_groups           = false
 }

--- a/templates/centrifydc_config.erb
+++ b/templates/centrifydc_config.erb
@@ -236,8 +236,8 @@ pam.allow.override: root
 #               -> "Manage login filters"
 #
 # You may also specify a file name with a list of users in the file
-pam.allow.users: file:/etc/centrifydc/users.allow
-pam.allow.groups: file:/etc/centrifydc/groups.allow
+<% if @local_allow %>pam.allow.users: file:/etc/centrifydc/users.allow
+pam.allow.groups: file:/etc/centrifydc/groups.allow <% end %>
 ## pam.allow.users: jdoe krusty
 ## pam.allow.groups: smokeallow
 # pam.deny.users: jcool
@@ -480,13 +480,13 @@ adclient.clients.socket2: /var/centrifydc/daemon2
 
 # How often should adclient flush it's entire cache.  0 means never.
 #
-adclient.cache.flush.interval: 24
+adclient.cache.flush.interval: <%= @cache_flush_int %>
 #
 
 # How many hours will a regular object live in the cache, regardless of
 # expiration time?  Default is forever.
 #
-adclient.cache.object.lifetime: 24
+adclient.cache.object.lifetime: <%= @cache_obj_life %>
 #
 
 # How often should the daemon clean up the cache, looking for old objects,
@@ -715,7 +715,7 @@ ord:pam.password.confirm.mesg: Confirm new password:
 #               -> "Security Options"
 #                   -> "Interactive Logon: Prompt user to change password before expiration"
 #
-pam.password.expiry.warn: 14
+pam.password.expiry.warn: <%= @password_warn %>
 #
 
 # What to do if, when a user is logging in, PAM discovers that the user's AD
@@ -1531,7 +1531,7 @@ w password length,\nlack of complexity or a minimum age for the current password
 #               -> "Enable SNTP client"
 #
 # If true, adclient will keep the system clock in sync with the domain.
-# adclient.sntp.enabled: true
+adclient.sntp.enabled: <%= @sntp_enabled %>
 #
 
 # The interval between sntp clock updates.  The value is the base 2
@@ -1921,9 +1921,7 @@ w password length,\nlack of complexity or a minimum age for the current password
 # as root. This list can be replaced using dzdo.env_delete as in the
 # following example.
 #
-# dzdo.env_delete: IFS,CDPATH,LOCALDOMAIN,RES_OPTIONS,HOSTALIASES, NLSPATH,PATH_LOCALE,LD_*,_RLD*,TERMINFO,TERMINFO_DIRS, TERMPATH,TERMCAP,ENV,BASH_ENV,PS4,GLOBIGN
-ORE,SHELLOPTS, JAVA_TOOL_OPTIONS,PERLIO_DEBUG,PERLLIB,PERL5LIB, PERL5OPT,PERL5DB,FPATH,NULLCMD,READNULLCMD,ZDOTDIR, TMPPREFIX,PYTHONHOME,PYTHONPATH,PYTHONINSPECT,R
-UBYLIB, RUBYOPT,KRB5_CONFIG,KRB5_KTNAME,VAR_ACE,USR_ACE,DLC_ACE, SHLIB_PATH, LDR_*,LIBPATH,DYLD_*
+# dzdo.env_delete: IFS,CDPATH,LOCALDOMAIN,RES_OPTIONS,HOSTALIASES,NLSPATH,PATH_LOCALE,LD_*,_RLD*,TERMINFO,TERMINFO_DIRS,TERMPATH,TERMCAP,ENV,BASH_ENV,PS4,GLOBIGNORE,SHELLOPTS,JAVA_TOOL_OPTIONS,PERLIO_DEBUG,PERLLIB,PERL5LIB,PERL5OPT,PERL5DB,FPATH,NULLCMD,READNULLCMD,ZDOTDIR,TMPPREFIX,PYTHONHOME,PYTHONPATH,PYTHONINSPECT,RUBYLIB,RUBYOPT,KRB5_CONFIG,KRB5_KTNAME,VAR_ACE,USR_ACE,DLC_ACE,SHLIB_PATH,LDR_*,LIBPATH,DYLD_*
 #
 
 #
@@ -2254,8 +2252,7 @@ nss.nobody.gid: 99
 # Don't call Centrify group or user iteration for these programs
 # This helps prevent adding local users and groups that conflict with
 # DirectControl users in AD
-nss.program.ignore: useradd,adduser,groupadd,addgroup,userdel,groupdel,usermod,groupmod,chfn,chsh,chpasswd,gpasswd,pwconv,pwunconv,grpconv,grpunconv,redhat-config-
-users
+nss.program.ignore: useradd,adduser,groupadd,addgroup,userdel,groupdel,usermod,groupmod,chfn,chsh,chpasswd,gpasswd,pwconv,pwunconv,grpconv,grpunconv,redhat-config-users,unix_chkpwd
 
 nss.shell.nologin: /sbin/nologin
 
@@ -2490,5 +2487,7 @@ nss.runtime.defaultvalue.var.domain: $DOMAIN
 # You must restart adclient to have this take effect.
 #
 # auto.schema.search.return.max: 1000
-<% @auth_servers.each do |as| %> dns.dc.<%= @adjoin_domain%>: <%= as %>
-<% end %>
+<% if @merge_groups %>adclient.local.group.merge: true <% else %># adclient.local.group.merge: false <% end %>
+<% if @auth_servers %><% @auth_servers.each do |as| %> dns.dc.<%= @adjoin_domain%>: <%= as %>
+<% end %><% end %>
+<% if @log_buffer %>logger.memory.enable.buffer: true<% end %>


### PR DESCRIPTION
Add support for Enterprise options (zone joins, no local allow files, etc.)
- Modify template, add more parameters, update adjoin logic
- Add extra parameter options for template values - cache_flush_int, cache_obj
- Modify and expand adjoin commands
- Add adinfo facts
- Clean up line feeds in dzdo.env_delete comment
