### PR TITLE
Add support for Enterprise options (zone joins, no local allow files, et...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,7 +84,7 @@ Below is a list of optional options and the default values:
 * lockout\_bad\_count: the bad count that would cause a lockout
 * merge\_groups: merge local group setting 
 * group\_overrides: an array of group id overrides that are found in the /etc/centrifydc/group.ovr file
-
+* manage\_conf: manage the Centrify configuration file (default: false) - set to true for Centrify Express or if desiring to manage the Centrify conf outside of Centrify
 **centrify::ssh::config_entry**
 
 since version 1.0 there is a new paradigm introduced for editing centrify's sshd options, in previous versions there have only been a few sshd options that have been provided as params, Now there is a new type *centrify::ssh::config_entry*. This type will add or change any config option for the centrify sshd config file

--- a/lib/facter/centrify_facts.rb
+++ b/lib/facter/centrify_facts.rb
@@ -1,0 +1,57 @@
+# Centrify facter facts
+require 'facter'
+
+# centrify_connected: true/nil
+Facter.add('centrify_connected') do
+  confine :kernel => :linux
+
+  setcode do
+    connected = nil
+    if File::executable?("/usr/bin/adinfo")
+      connected = Facter::Util::Resolution.exec("/usr/bin/adinfo -m")
+      if connected == connected
+        connected = true
+      end
+    end
+    connected
+  end
+end
+
+# centrify domain controller
+Facter.add('centrify_dc') do
+  confine :centrify_connected => true
+
+  setcode do
+    dc = Facter::Util::Resolution.exec('/usr/bin/adinfo -r')
+    dc.nil? ? nil : dc
+  end
+end
+
+# centrify domain
+Facter.add('centrify_domain') do
+  confine :centrify_connected => true
+
+  setcode do
+    domain = Facter::Util::Resolution.exec('/usr/bin/adinfo -d')
+    domain.nil? ? nil : domain
+  end
+end
+
+# centrify mode
+Facter.add('centrify_mode') do
+
+  setcode do
+    mode = Facter::Util::Resolution.exec('/usr/bin/adinfo -m')
+    mode.nil? ? nil : mode
+  end
+end
+
+# centrify zone
+Facter.add('centrify_zone') do
+  confine :centrify_connected => true
+
+  setcode do
+    zone = Facter::Util::Resolution.exec('/usr/bin/adinfo -z')
+    zone.nil? ? nil : zone
+  end
+end

--- a/lib/facter/centrify_facts.rb
+++ b/lib/facter/centrify_facts.rb
@@ -1,57 +1,59 @@
 # Centrify facter facts
 require 'facter'
 
-# centrify_connected: true/nil
-Facter.add('centrify_connected') do
+# centrify mode
+Facter.add('centrify_mode') do
   confine :kernel => :linux
 
   setcode do
-    connected = nil
     if File::executable?("/usr/bin/adinfo")
-      connected = Facter::Util::Resolution.exec("/usr/bin/adinfo -m")
-      if connected == connected
-        connected = true
-      end
+      mode = Facter::Util::Resolution.exec("/usr/bin/adinfo -m")
+      mode.empty? ? 'null' : mode
+    else
+      'null'
     end
-    connected
   end
 end
 
 # centrify domain controller
 Facter.add('centrify_dc') do
-  confine :centrify_connected => true
+  confine :kernel => :linux
 
   setcode do
-    dc = Facter::Util::Resolution.exec('/usr/bin/adinfo -r')
-    dc.nil? ? nil : dc
+    if File::executable?("/usr/bin/adinfo")
+      dc = Facter::Util::Resolution.exec('/usr/bin/adinfo -r')
+      dc.empty? ? 'null' : dc
+    else
+      nil
+    end
   end
 end
 
 # centrify domain
 Facter.add('centrify_domain') do
-  confine :centrify_connected => true
+  confine :kernel => :linux
 
   setcode do
-    domain = Facter::Util::Resolution.exec('/usr/bin/adinfo -d')
-    domain.nil? ? nil : domain
+    if File::executable?("/usr/bin/adinfo")
+      domain = Facter::Util::Resolution.exec('/usr/bin/adinfo -d')
+      domain.empty? ? 'null' : domain
+    else
+      nil
+    end
   end
 end
 
-# centrify mode
-Facter.add('centrify_mode') do
-
-  setcode do
-    mode = Facter::Util::Resolution.exec('/usr/bin/adinfo -m')
-    mode.nil? ? nil : mode
-  end
-end
 
 # centrify zone
 Facter.add('centrify_zone') do
-  confine :centrify_connected => true
+  confine :kernel => :linux
 
   setcode do
-    zone = Facter::Util::Resolution.exec('/usr/bin/adinfo -z')
-    zone.nil? ? nil : zone
+    if File::executable?("/usr/bin/adinfo")
+      zone = Facter::Util::Resolution.exec('/usr/bin/adinfo -z')
+      zone.empty? ? 'null' : zone
+    else
+      nil
+    end
   end
 end

--- a/lib/facter/centrify_facts.rb
+++ b/lib/facter/centrify_facts.rb
@@ -57,3 +57,20 @@ Facter.add('centrify_zone') do
     end
   end
 end
+
+# centrify bind
+Facter.add('centrify_bind') do
+  confine :kernel => :linux
+
+  setcode do
+    if File::executable?("/usr/bin/adinfo")
+      result = Facter::Util::Resolution.exec('/usr/bin/adinfo -C | grep Cannot')
+      if result.nil?
+        'bad_result'
+      end
+      result.empty? ? true : false
+    else
+      nil
+    end
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class centrify::config {
   $adjoin_enterprise_zone = $centrify::adjoin_enterprise_zone
   $local_allow            = $centrify::local_allow
   $group_overrides        = $centrify::group_overrides
+  $manage_conf            = $centrify::manage_conf
 
   # Error check for no zone and no auth servers
   if $adjoin_enterprise_zone == '' and size ($auth_servers) == 0 {
@@ -44,8 +45,8 @@ class centrify::config {
       fail('you must give an ad server name to join to')
     }
   }
-  # If using an Enterprise zone, let Centrify manage the conf file
-  if $adjoin_enterprise_zone == '' {
+
+  if $manage_conf == true {
     file {'/etc/centrifydc/centrifydc.conf':
       owner   => 'root',
       group   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,17 +5,17 @@
 #
 #
 class centrify::config {
-  $auth_servers    = $centrify::auth_servers
-  $users_allow     = $centrify::users_allow
-  $groups_allow    = $centrify::groups_allow
-  $adjoin_domain   = $centrify::adjoin_domain
-  $adjoin_server   = $centrify::adjoin_server
-  $adjoin_zone     = $centrify::adjoin_zone
-  $local_allow     = $centrify::local_allow
-  $group_overrides = $centrify::group_overrides
+  $auth_servers           = $centrify::auth_servers
+  $users_allow            = $centrify::users_allow
+  $groups_allow           = $centrify::groups_allow
+  $adjoin_domain          = $centrify::adjoin_domain
+  $adjoin_server          = $centrify::adjoin_server
+  $adjoin_enterprise_zone = $centrify::adjoin_enterprise_zone
+  $local_allow            = $centrify::local_allow
+  $group_overrides        = $centrify::group_overrides
 
   # Error check for no zone and no auth servers
-  if $adjoin_zone == '' and size ($auth_servers) == 0 {
+  if $adjoin_enterprise_zone == '' and size ($auth_servers) == 0 {
       fail('you must provide either a zone or at least one auth server for this to work')
   }
 
@@ -39,18 +39,20 @@ class centrify::config {
   }
 
   # If not joing a zone, error check if the join server is not given
-  if $adjoin_zone == '' {
+  if $adjoin_enterprise_zone == '' {
     if size($adjoin_server) == 0 {
       fail('you must give an ad server name to join to')
     }
   }
-
-  file {'/etc/centrifydc/centrifydc.conf':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('centrify/centrifydc_config.erb'),
-    notify  => Class['centrify::service'],
+  # If using an Enterprise zone, let Centrify manage the conf file
+  if $adjoin_enterprise_zone == '' {
+    file {'/etc/centrifydc/centrifydc.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('centrify/centrifydc_config.erb'),
+      notify  => Class['centrify::service'],
+    }
   }
 
   if $local_allow == true {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -51,7 +51,7 @@ class centrify::config {
       group   => 'root',
       mode    => '0644',
       content => template('centrify/centrifydc_config.erb'),
-      notify  => Class['centrify::service'],
+      notify  => [ Class['centrify::service'], Service['centrify-ssh-service'], Service['centrify-dc-service'] ],
     }
   }
 
@@ -61,7 +61,7 @@ class centrify::config {
       group   => 'root',
       mode    => '0644',
       content => template('centrify/groups_allow.erb'),
-      notify  => Class['centrify::service'],
+      notify  => [ Class['centrify::service'], Service['centrify-ssh-service'], Service['centrify-dc-service'] ],
     }
   }
   else {
@@ -76,7 +76,7 @@ class centrify::config {
       group   => 'root',
       mode    => '0644',
       content => template('centrify/users_allow.erb'),
-      notify  => Class['centrify::service']
+      notify  => [ Class['centrify::service'], Service['centrify-ssh-service'], Service['centrify-dc-service'] ],
     }
   }
   else {
@@ -91,7 +91,7 @@ class centrify::config {
       group   => 'root',
       mode    => '0644',
       content => template('centrify/group.ovr.erb'),
-      notify  => Class['centrify::service']
+      notify  => [ Class['centrify::service'], Service['centrify-ssh-service'], Service['centrify-dc-service'] ],
     }
   }
   else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class centrify (
   $lockout_bad_count      = $centrify::params::lockout_bad_count,
   $sntp_enabled           = $centrify::params::sntp_enabled,
   $merge_groups           = $centrify::params::merge_groups,
+  $manage_conf            = $centrify::params::manage_conf,
 ) inherits centrify::params {
 
   # validate parameters
@@ -86,6 +87,7 @@ class centrify (
   validate_string($lockout_bad_count)
   validate_bool($sntp_enabled)
   validate_bool($merge_groups)
+  validate_bool($manage_conf)
 
   # include classes for install, config and services
   include '::centrify::install'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,12 +94,8 @@ class centrify (
   include '::centrify::config'
   include '::centrify::service'
 
-  # set anchors for begin and end
-  anchor { '::centrify::begin': }
-  anchor { '::centrify::end': }
-
   # ordering of class execution
-  Anchor ['::centrify::begin'] -> Class ['::centrify::install'] ->
+  anchor { 'centrify_begin': } -> Class ['::centrify::install'] ->
   Class['::centrify::config'] ~> Class['::centrify::service'] ->
-  Anchor['::centrify::end']
+  anchor { 'centrify_end': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class centrify (
   $adjoin_password        = $centrify::params::adjoin_password,
   $adjoin_domain          = $centrify::params::adjoin_domain,
   $adjoin_server          = $centrify::params::adjoin_server,
-  $adjoin_zone            = $centrify::params::adjoin_zone,
+  $adjoin_enterprise_zone = $centrify::params::adjoin_enterprise_zone,
   $adjoin_container       = $centrify::params::adjoin_container,
   $adjoin_force           = $centrify::params::adjoin_force,
   $private_group          = $centrify::params::private_group,
@@ -70,7 +70,7 @@ class centrify (
   validate_string($adjoin_password)
   validate_string($adjoin_domain)
   validate_string($adjoin_server)
-  validate_string($adjoin_zone)
+  validate_string($adjoin_enterprise_zone)
   validate_string($adjoin_container)
   validate_bool($adjoin_force)
   validate_bool($private_group)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@ class centrify (
   $ssh_service_enable     = $centrify::params::ssh_service_enable,
   $ssh_service_ensure     = $centrify::params::ssh_service_ensure,
   $auth_servers           = $centrify::params::auth_servers,
+  $local_allow            = $centrify::params::local_allow,
   $group_overrides        = $centrify::params::group_overrides,
   $groups_allow           = $centrify::params::groups_allow,
   $users_allow            = $centrify::params::users_allow,
@@ -31,13 +32,21 @@ class centrify (
   $adjoin_password        = $centrify::params::adjoin_password,
   $adjoin_domain          = $centrify::params::adjoin_domain,
   $adjoin_server          = $centrify::params::adjoin_server,
+  $adjoin_zone            = $centrify::params::adjoin_zone,
+  $adjoin_container       = $centrify::params::adjoin_container,
+  $adjoin_force           = $centrify::params::adjoin_force,
   $private_group          = $centrify::params::private_group,
   $primary_gid            = $centrify::params::primary_gid,
   $auto_join              = $centrify::params::auto_join,
+  $cache_flush_int        = $centrify::params::cache_flush_int,
+  $cache_obj_life         = $centrify::params::cache_obj_life,
+  $log_buffer             = $centrify::params::log_buffer,
   $maximum_password_age   = $centrify::params::maximum_password_age,
   $minimum_password_age   = $centrify::params::minimum_password_age,
+  $password_warn          = $centrify::params::password_warn,
   $lockout_duration       = $centrify::params::lockout_duration,
   $lockout_bad_count      = $centrify::params::lockout_bad_count,
+  $sntp_enabled           = $centrify::params::sntp_enabled,
   $merge_groups           = $centrify::params::merge_groups,
 ) inherits centrify::params {
 
@@ -53,6 +62,7 @@ class centrify (
   validate_bool($ssh_service_enable)
   validate_string($ssh_service_ensure)
   validate_array($auth_servers)
+  validate_bool($local_allow)
   validate_array($group_overrides)
   validate_array($groups_allow)
   validate_array($users_allow)
@@ -60,13 +70,21 @@ class centrify (
   validate_string($adjoin_password)
   validate_string($adjoin_domain)
   validate_string($adjoin_server)
+  validate_string($adjoin_zone)
+  validate_string($adjoin_container)
+  validate_bool($adjoin_force)
   validate_bool($private_group)
   validate_string($primary_gid)
   validate_bool($auto_join)
+  validate_string($cache_flush_int)
+  validate_string($cache_obj_life)
+  validate_bool($log_buffer)
   validate_string($maximum_password_age)
   validate_string($minimum_password_age)
+  validate_string($password_warn)
   validate_string($lockout_duration)
   validate_string($lockout_bad_count)
+  validate_bool($sntp_enabled)
   validate_bool($merge_groups)
 
   # include classes for install, config and services

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,14 +77,14 @@ class centrify (
   validate_bool($private_group)
   validate_string($primary_gid)
   validate_bool($auto_join)
-  validate_string($cache_flush_int)
-  validate_string($cache_obj_life)
+  validate_integer($cache_flush_int)
+  validate_integer($cache_obj_life)
   validate_bool($log_buffer)
-  validate_string($maximum_password_age)
-  validate_string($minimum_password_age)
-  validate_string($password_warn)
-  validate_string($lockout_duration)
-  validate_string($lockout_bad_count)
+  validate_integer($maximum_password_age)
+  validate_integer($minimum_password_age)
+  validate_integer($password_warn)
+  validate_integer($lockout_duration)
+  validate_integer($lockout_bad_count)
   validate_bool($sntp_enabled)
   validate_bool($merge_groups)
   validate_bool($manage_conf)
@@ -95,7 +95,7 @@ class centrify (
   include '::centrify::service'
 
   # ordering of class execution
-  anchor { 'centrify_begin': } -> Class ['::centrify::install'] ->
+  anchor { 'centrify_begin': } -> Class['::centrify::install'] ->
   Class['::centrify::config'] ~> Class['::centrify::service'] ->
   anchor { 'centrify_end': }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,5 +51,5 @@ class centrify::params {
   $lockout_bad_count      = '0'
   $sntp_enabled           = false
   $merge_groups           = false
-  $manage_conf            = false
+  $manage_conf            = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class centrify::params {
   $adjoin_password        = ''
   $adjoin_domain          = ''
   $adjoin_server          = ''
-  $adjoin_zone            = ''
+  $adjoin_enterprise_zone = ''
   $adjoin_container       = ''
   $adjoin_force           = false
   $private_group          = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class centrify::params {
   $ssh_service_enable     = true
   $ssh_service_ensure     = 'running'
   $auth_servers           = []
+  $local_allow            = true
   $group_overrides        = []
   $groups_allow           = []
   $users_allow            = []
@@ -34,12 +35,20 @@ class centrify::params {
   $adjoin_password        = ''
   $adjoin_domain          = ''
   $adjoin_server          = ''
+  $adjoin_zone            = ''
+  $adjoin_container       = ''
+  $adjoin_force           = false
   $private_group          = true
   $primary_gid            = ''
   $auto_join              = true
+  $cache_flush_int        = '24'
+  $cache_obj_life         = '24'
+  $log_buffer             = false
   $maximum_password_age   = '90'
   $minimum_password_age   = '1'
+  $password_warn          = '14'
   $lockout_duration       = '30'
   $lockout_bad_count      = '0'
+  $sntp_enabled           = false
   $merge_groups           = false
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,4 +51,5 @@ class centrify::params {
   $lockout_bad_count      = '0'
   $sntp_enabled           = false
   $merge_groups           = false
+  $manage_conf            = false
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -49,7 +49,7 @@ class centrify::service {
     # adjoin Centrify Enterprise
     exec { 'adjoin Centrify Enterprise':
       path      => '/usr/bin:/usr/sbin:/bin',
-      command   => "adjoin -u ${adjoin_user} -p ${adjoin_password} -c ${adjoin_container} -z ${adjoin_enterprise_zone} -n ${::fqdn} -f ${adjoin_domain}",
+      command   => "adlicense -l && adjoin -u ${adjoin_user} -p ${adjoin_password} -c ${adjoin_container} -z ${adjoin_enterprise_zone} -n ${::fqdn} -f ${adjoin_domain}",
       onlyif    => ['test `adinfo -d | wc -l` -eq 0',
                     "test '${adjoin_enterprise_zone}' != ''"
                     ],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,17 +22,6 @@ class centrify::service {
   $dc_service_enable      = $centrify::dc_service_enable
   $local_allow            = $centrify::local_allow
 
-  if $local_allow == true {
-    $config = [File['/etc/centrifydc/centrifydc.conf'],
-              File['/etc/centrifydc/groups.allow'],
-              File['/etc/centrifydc/users.allow'],
-              ]
-  }
-  else {
-    $config = [File['/etc/centrifydc/centrifydc.conf'],
-              ]
-  }
-
   if $auto_join {
 
     notice('running with auto_join enabled')
@@ -80,7 +69,6 @@ class centrify::service {
       hasrestart => true,
       hasstatus  => true,
       enable     => $ssh_service_enable,
-      subscribe  => $config,
       notify     => Exec['adflush'],
     }
 
@@ -90,7 +78,6 @@ class centrify::service {
       hasrestart => true,
       hasstatus  => true,
       enable     => $dc_service_enable,
-      subscribe  => $config,
       notify     => Exec['adflush'],
     }
 

--- a/manifests/user/home_dir.pp
+++ b/manifests/user/home_dir.pp
@@ -14,10 +14,10 @@ define centrify::user::home_dir (
       # main home directory
       if $ensure == 'present' {
         file {"/home/${name}":
-          ensure  => 'directory',
-          owner   => $sid,
-          group   => $sid,
-          mode    => 0600,
+          ensure => 'directory',
+          owner  => $sid,
+          group  => $sid,
+          mode   => '0600',
         }
 
         # bashrc file
@@ -26,7 +26,7 @@ define centrify::user::home_dir (
             ensure  => 'present',
             owner   => $sid,
             group   => $sid,
-            mode    => 0740,
+            mode    => '0740',
             source  => $bashrc_file,
             require => File["/home/${name}"],
           }
@@ -43,7 +43,7 @@ define centrify::user::home_dir (
             ensure  => 'directory',
             owner   => $sid,
             group   => $sid,
-            mode    => 0600,
+            mode    => '0600',
             require => File["/home/${name}"],
           }
 
@@ -53,7 +53,7 @@ define centrify::user::home_dir (
               ensure  => 'present',
               owner   => $sid,
               group   => $sid,
-              mode    => 0744,
+              mode    => '0744',
               source  => $ssh_public_key,
               require => File["/home/${name}/.ssh"],
             }
@@ -69,7 +69,7 @@ define centrify::user::home_dir (
               ensure  => 'present',
               owner   => $sid,
               group   => $sid,
-              mode    => 0744,
+              mode    => '0744',
               source  => $ssh_private_key,
               require => File["/home/${name}/.ssh"],
             }
@@ -85,7 +85,7 @@ define centrify::user::home_dir (
               ensure  => 'present',
               owner   => $sid,
               group   => $sid,
-              mode    => 0744,
+              mode    => '0744',
               source  => $authorized_keys,
               require => File["/home/${name}/.ssh"],
             }

--- a/templates/centrifydc_config.erb
+++ b/templates/centrifydc_config.erb
@@ -236,8 +236,8 @@ pam.allow.override: root
 #               -> "Manage login filters"
 #
 # You may also specify a file name with a list of users in the file
-pam.allow.users: file:/etc/centrifydc/users.allow
-pam.allow.groups: file:/etc/centrifydc/groups.allow
+<% if @local_allow %>pam.allow.users: file:/etc/centrifydc/users.allow
+pam.allow.groups: file:/etc/centrifydc/groups.allow <% end %>
 ## pam.allow.users: jdoe krusty
 ## pam.allow.groups: smokeallow
 # pam.deny.users: jcool
@@ -480,13 +480,13 @@ adclient.clients.socket2: /var/centrifydc/daemon2
 
 # How often should adclient flush it's entire cache.  0 means never.
 #
-adclient.cache.flush.interval: 24
+adclient.cache.flush.interval: <%= @cache_flush_int %>
 #
 
 # How many hours will a regular object live in the cache, regardless of
 # expiration time?  Default is forever.
 #
-adclient.cache.object.lifetime: 24
+adclient.cache.object.lifetime: <%= @cache_obj_life %>
 #
 
 # How often should the daemon clean up the cache, looking for old objects,
@@ -715,7 +715,7 @@ ord:pam.password.confirm.mesg: Confirm new password:
 #               -> "Security Options"
 #                   -> "Interactive Logon: Prompt user to change password before expiration"
 #
-pam.password.expiry.warn: 14
+pam.password.expiry.warn: <%= @password_warn %>
 #
 
 # What to do if, when a user is logging in, PAM discovers that the user's AD
@@ -1531,7 +1531,7 @@ w password length,\nlack of complexity or a minimum age for the current password
 #               -> "Enable SNTP client"
 #
 # If true, adclient will keep the system clock in sync with the domain.
-# adclient.sntp.enabled: true
+adclient.sntp.enabled: <%= @sntp_enabled %>
 #
 
 # The interval between sntp clock updates.  The value is the base 2
@@ -1921,9 +1921,7 @@ w password length,\nlack of complexity or a minimum age for the current password
 # as root. This list can be replaced using dzdo.env_delete as in the
 # following example.
 #
-# dzdo.env_delete: IFS,CDPATH,LOCALDOMAIN,RES_OPTIONS,HOSTALIASES, NLSPATH,PATH_LOCALE,LD_*,_RLD*,TERMINFO,TERMINFO_DIRS, TERMPATH,TERMCAP,ENV,BASH_ENV,PS4,GLOBIGN
-ORE,SHELLOPTS, JAVA_TOOL_OPTIONS,PERLIO_DEBUG,PERLLIB,PERL5LIB, PERL5OPT,PERL5DB,FPATH,NULLCMD,READNULLCMD,ZDOTDIR, TMPPREFIX,PYTHONHOME,PYTHONPATH,PYTHONINSPECT,R
-UBYLIB, RUBYOPT,KRB5_CONFIG,KRB5_KTNAME,VAR_ACE,USR_ACE,DLC_ACE, SHLIB_PATH, LDR_*,LIBPATH,DYLD_*
+# dzdo.env_delete: IFS,CDPATH,LOCALDOMAIN,RES_OPTIONS,HOSTALIASES,NLSPATH,PATH_LOCALE,LD_*,_RLD*,TERMINFO,TERMINFO_DIRS,TERMPATH,TERMCAP,ENV,BASH_ENV,PS4,GLOBIGNORE,SHELLOPTS,JAVA_TOOL_OPTIONS,PERLIO_DEBUG,PERLLIB,PERL5LIB,PERL5OPT,PERL5DB,FPATH,NULLCMD,READNULLCMD,ZDOTDIR,TMPPREFIX,PYTHONHOME,PYTHONPATH,PYTHONINSPECT,RUBYLIB,RUBYOPT,KRB5_CONFIG,KRB5_KTNAME,VAR_ACE,USR_ACE,DLC_ACE,SHLIB_PATH,LDR_*,LIBPATH,DYLD_*
 #
 
 #
@@ -2254,8 +2252,7 @@ nss.nobody.gid: 99
 # Don't call Centrify group or user iteration for these programs
 # This helps prevent adding local users and groups that conflict with
 # DirectControl users in AD
-nss.program.ignore: useradd,adduser,groupadd,addgroup,userdel,groupdel,usermod,groupmod,chfn,chsh,chpasswd,gpasswd,pwconv,pwunconv,grpconv,grpunconv,redhat-config-
-users
+nss.program.ignore: useradd,adduser,groupadd,addgroup,userdel,groupdel,usermod,groupmod,chfn,chsh,chpasswd,gpasswd,pwconv,pwunconv,grpconv,grpunconv,redhat-config-users,unix_chkpwd
 
 nss.shell.nologin: /sbin/nologin
 
@@ -2490,5 +2487,7 @@ nss.runtime.defaultvalue.var.domain: $DOMAIN
 # You must restart adclient to have this take effect.
 #
 # auto.schema.search.return.max: 1000
-<% @auth_servers.each do |as| %> dns.dc.<%= @adjoin_domain%>: <%= as %>
-<% end %>
+<% if @merge_groups %>adclient.local.group.merge: true <% else %># adclient.local.group.merge: false <% end %>
+<% if @auth_servers %><% @auth_servers.each do |as| %> dns.dc.<%= @adjoin_domain%>: <%= as %>
+<% end %><% end %>
+<% if @log_buffer %>logger.memory.enable.buffer: true<% end %>


### PR DESCRIPTION
Add support for Enterprise options (zone joins, no local allow files, etc.)
- Modify template, add more parameters, update adjoin logic
- Add extra parameter options for template values - cache_flush_int, cache_obj
- Modify and expand adjoin commands
- Add adinfo facts
- Clean up line feeds in dzdo.env_delete comment
